### PR TITLE
Update session_store.rb  change encrypt_cookie_~

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-BootstrapApp::Application.config.session_store :encrypted_cookie_store, key: '_bootstrap_app_session'
+BootstrapApp::Application.config.session_store :cookie_store, key: '_bootstrap_app_session'


### PR DESCRIPTION
It's rails 4 change log
https://github.com/rails/rails/blob/master/actionpack/CHANGELOG.md

Automatically configure cookie-based sessions to be encrypted if secret_key_base is set, falling back to signed if only secret_token is set. Automatically upgrade existing signed cookie-based sessions from Rails 3.x to be encrypted if both secret_key_base and secret_token are set, or signed with the new key generator if only secret_token is set. This leaves only the config.session_store :cookie_store option and removes the two new options introduced in 4.0.0.beta1: encrypted_cookie_store and upgrade_signature_to_encryption_cookie_store.
